### PR TITLE
Add an option to use compact or pretty JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2021"
 actix-web = "4.9.0"
 actix-web-prom = "0.8.0"
 chrono = "0.4.38"
-clap = { version = "4.5.17", features = ["derive"] }
+clap = { version = "4.5.18", features = ["derive"] }
 env_logger = "0.11.5"
 log = "0.4.22"
 maxminddb = "0.24.0"
 serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
Query string `?compact` or  `?compact=anything` will return compact JSON for all endpoints. The default behavior is now pretty JSON format. 